### PR TITLE
Simplify the command line interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ FROM builder as run
 # Install the package.
 RUN pip install .
 
-ENTRYPOINT ["datacatalog-tag-manager"]
+ENTRYPOINT ["datacatalog-tags"]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ the Tags and Fields you need.
 - Python + virtualenv
 
 ```bash
-datacatalog-tag-manager create-tags --csv-file CSV_FILE_PATH
+datacatalog-tags create --csv-file CSV_FILE_PATH
 ```
 
 - Docker
@@ -127,7 +127,7 @@ datacatalog-tag-manager create-tags --csv-file CSV_FILE_PATH
 docker build --rm --tag datacatalog-tag-manager .
 docker run --rm --tty \
   --volume CREDENTIALS_FILE_FOLDER:/credentials --volume CSV_FILE_FOLDER:/data \
-  datacatalog-tag-manager create-tags --csv-file /data/CSV_FILE_NAME
+  datacatalog-tag-manager create --csv-file /data/CSV_FILE_NAME
 ```
 
 ### 2.2. Delete
@@ -150,7 +150,7 @@ the Tags you want.
 - Python + virtualenv
 
 ```bash
-datacatalog-tag-manager delete-tags --csv-file CSV_FILE_PATH
+datacatalog-tags delete --csv-file CSV_FILE_PATH
 ```
 
 - Docker
@@ -159,7 +159,7 @@ datacatalog-tag-manager delete-tags --csv-file CSV_FILE_PATH
 docker build --rm --tag datacatalog-tag-manager .
 docker run --rm --tty \
   --volume CREDENTIALS_FILE_FOLDER:/credentials --volume CSV_FILE_FOLDER:/data \
-  datacatalog-tag-manager delete-tags --csv-file /data/CSV_FILE_NAME
+  datacatalog-tag-manager delete --csv-file /data/CSV_FILE_NAME
 ```
 
 [1]: https://circleci.com/gh/ricardolsmendes/datacatalog-tag-manager.svg?style=svg

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,12 @@ setuptools.setup(
     package_dir={'': 'src'},
     entry_points={
         'console_scripts': [
-            'datacatalog-tag-manager = datacatalog_tag_manager:main',
+            'datacatalog-tags = datacatalog_tag_manager:main',
         ],
     },
     include_package_data=True,
     install_requires=(
-        'google-cloud-datacatalog',
+        'google-cloud-datacatalog>=1,<2',
         'pandas',
     ),
     setup_requires=('pytest-runner', ),

--- a/src/datacatalog_tag_manager/tag_manager_cli.py
+++ b/src/datacatalog_tag_manager/tag_manager_cli.py
@@ -25,13 +25,13 @@ class TagManagerCLI:
 
         subparsers = parser.add_subparsers()
 
-        create_tags_parser = subparsers.add_parser('create-tags', help='Create Tags')
+        create_tags_parser = subparsers.add_parser('create', help='Create Tags')
         create_tags_parser.add_argument('--csv-file',
                                         help='CSV file with Tags information',
                                         required=True)
         create_tags_parser.set_defaults(func=cls.__create_tags)
 
-        delete_tags_parser = subparsers.add_parser('delete-tags', help='Delete Tags')
+        delete_tags_parser = subparsers.add_parser('delete', help='Delete Tags')
         delete_tags_parser.add_argument('--csv-file',
                                         help='CSV file with Tags information',
                                         required=True)

--- a/tests/datacatalog_tag_manager/tag_manager_cli_test.py
+++ b/tests/datacatalog_tag_manager/tag_manager_cli_test.py
@@ -12,10 +12,10 @@ class TagManagerCLITest(unittest.TestCase):
                           ['invalid-subcommand'])
 
     def test_parse_args_create_tags_missing_mandatory_args_should_raise_system_exit(self):
-        self.assertRaises(SystemExit, tag_manager_cli.TagManagerCLI._parse_args, ['create-tags'])
+        self.assertRaises(SystemExit, tag_manager_cli.TagManagerCLI._parse_args, ['create'])
 
     def test_parse_args_create_tags_should_parse_mandatory_args(self):
-        args = tag_manager_cli.TagManagerCLI._parse_args(['create-tags', '--csv-file', 'test.csv'])
+        args = tag_manager_cli.TagManagerCLI._parse_args(['create', '--csv-file', 'test.csv'])
         self.assertEqual('test.csv', args.csv_file)
 
     def test_run_no_args_should_raise_attribute_error(self):
@@ -24,7 +24,7 @@ class TagManagerCLITest(unittest.TestCase):
     @mock.patch(
         'datacatalog_tag_manager.tag_manager_cli.tag_datasource_processor.TagDatasourceProcessor')
     def test_run_create_tags_should_call_tag_creator(self, mock_tag_datasource_processor):
-        tag_manager_cli.TagManagerCLI.run(['create-tags', '--csv-file', 'test.csv'])
+        tag_manager_cli.TagManagerCLI.run(['create', '--csv-file', 'test.csv'])
 
         tag_datasource_processor = mock_tag_datasource_processor.return_value
         tag_datasource_processor.create_tags_from_csv.assert_called_once()
@@ -33,7 +33,7 @@ class TagManagerCLITest(unittest.TestCase):
     @mock.patch(
         'datacatalog_tag_manager.tag_manager_cli.tag_datasource_processor.TagDatasourceProcessor')
     def test_run_delete_tags_should_call_tag_creator(self, mock_tag_datasource_processor):
-        tag_manager_cli.TagManagerCLI.run(['delete-tags', '--csv-file', 'test.csv'])
+        tag_manager_cli.TagManagerCLI.run(['delete', '--csv-file', 'test.csv'])
 
         tag_datasource_processor = mock_tag_datasource_processor.return_value
         tag_datasource_processor.delete_tags_from_csv.assert_called_once()


### PR DESCRIPTION
This PR replaces the commands `datacatalog-tag-manager create-tags` and  `datacatalog-tag-manager delete-tags` with `datacatalog-tags create` and `datacatalog-tags delete`.