### PR TITLE
Adiciona suporte a tags do tipo "richtext"

### DIFF
--- a/src/datacatalog_tag_manager/datacatalog_entity_factory.py
+++ b/src/datacatalog_tag_manager/datacatalog_entity_factory.py
@@ -61,7 +61,8 @@ class DataCatalogEntityFactory:
             datacatalog.FieldType.PrimitiveType.BOOL: cls.__set_bool_field_value,
             datacatalog.FieldType.PrimitiveType.DOUBLE: cls.__set_double_field_value,
             datacatalog.FieldType.PrimitiveType.STRING: cls.__set_string_field_value,
-            datacatalog.FieldType.PrimitiveType.TIMESTAMP: cls.__set_timestamp_field_value
+            datacatalog.FieldType.PrimitiveType.TIMESTAMP: cls.__set_timestamp_field_value,
+            datacatalog.FieldType.PrimitiveType.RICHTEXT: cls.__set_richtext_field_value
         }
 
         primitive_type = template_field_type.primitive_type
@@ -119,3 +120,11 @@ class DataCatalogEntityFactory:
         timestamp = timestamp_pb2.Timestamp()
         timestamp.FromDatetime(dt)
         field.timestamp_value = timestamp
+
+    @classmethod
+    def __set_richtext_field_value(cls, field, value):
+        """
+        :param field: The field.
+        :param value: A richtext value.
+        """
+        field.richtext_value = value

--- a/src/datacatalog_tag_manager/datacatalog_entity_factory.py
+++ b/src/datacatalog_tag_manager/datacatalog_entity_factory.py
@@ -60,9 +60,9 @@ class DataCatalogEntityFactory:
         set_primitive_field_value_functions = {
             datacatalog.FieldType.PrimitiveType.BOOL: cls.__set_bool_field_value,
             datacatalog.FieldType.PrimitiveType.DOUBLE: cls.__set_double_field_value,
+            datacatalog.FieldType.PrimitiveType.RICHTEXT: cls.__set_richtext_field_value,
             datacatalog.FieldType.PrimitiveType.STRING: cls.__set_string_field_value,
-            datacatalog.FieldType.PrimitiveType.TIMESTAMP: cls.__set_timestamp_field_value,
-            datacatalog.FieldType.PrimitiveType.RICHTEXT: cls.__set_richtext_field_value
+            datacatalog.FieldType.PrimitiveType.TIMESTAMP: cls.__set_timestamp_field_value
         }
 
         primitive_type = template_field_type.primitive_type
@@ -103,13 +103,21 @@ class DataCatalogEntityFactory:
         field.enum_value.display_name = value
 
     @classmethod
+    def __set_richtext_field_value(cls, field, value):
+        """
+        :param field: The field.
+        :param value: A string value.
+        """
+        field.richtext_value = value
+
+    @classmethod
     def __set_string_field_value(cls, field, value):
         """
         :param field: The field.
         :param value: A string value.
         """
         field.string_value = value
-
+        
     @classmethod
     def __set_timestamp_field_value(cls, field, value):
         """
@@ -120,11 +128,3 @@ class DataCatalogEntityFactory:
         timestamp = timestamp_pb2.Timestamp()
         timestamp.FromDatetime(dt)
         field.timestamp_value = timestamp
-
-    @classmethod
-    def __set_richtext_field_value(cls, field, value):
-        """
-        :param field: The field.
-        :param value: A richtext value.
-        """
-        field.richtext_value = value

--- a/tests/datacatalog_tag_manager/datacatalog_entity_factory_test.py
+++ b/tests/datacatalog_tag_manager/datacatalog_entity_factory_test.py
@@ -11,6 +11,7 @@ from datacatalog_tag_manager import datacatalog_entity_factory
 class DataCatalogEntityFactoryTest(unittest.TestCase):
     __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
     __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __RICHTEXT_TYPE = datacatalog.FieldType.PrimitiveType.RICHTEXT
     __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
     __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
 
@@ -61,6 +62,19 @@ class DataCatalogEntityFactoryTest(unittest.TestCase):
 
         self.assertEqual(2.5, tag.fields['test_double_field'].double_value)
         self.assertEqual(3.1415, tag.fields['test_double_field_str'].double_value)
+
+    def test_make_tag_valid_richtext_value_should_set_field(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'test_template'
+        tag_template.fields['test_richtext_field'] = \
+            make_primitive_type_template_field(self.__RICHTEXT_TYPE)
+
+        tag_fields = {'test_richtext_field': 'Test [bold blue]RichText[/bold blue] :thumbs_up:'}
+
+        tag = datacatalog_entity_factory.DataCatalogEntityFactory.make_tag(
+            tag_template, tag_fields)
+
+        self.assertEqual('Test Richtext Value', tag.fields['test_richtext_field'].richtext_value)
 
     def test_make_tag_valid_string_value_should_set_field(self):
         tag_template = datacatalog.TagTemplate()


### PR DESCRIPTION
Adição do método e da entrada para recebimento de dados no formato Rich Text. O tipo richtext suporta um volume maior de caracteres na tag (10k)