### PR TITLE
chore: specify the dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,17 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=(
-        'google-cloud-datacatalog ~= 3.0',
-        'numpy >= 1.19.0, <= 1.19.3',
-        'pandas ~= 1.1.4',
+        'google-cloud-datacatalog ~=3.8.1',
+        'numpy >=1.19.0, <=1.19.3',
+        'pandas ~=1.1.4',
     ),
-    setup_requires=('pytest-runner', ),
+    setup_requires=('pytest-runner ~=5.3.2', ),
     tests_require=(
-        'pytest-cov',
-        'tomli ~= 1.2.2',
+        'coverage ==6.2',
+        'pytest ~=7.0.1',
+        'pytest-cov ~=2.12.1',
+        'typing-extensions ==4.1.1',
+        'tomli ~=1.2.3',
     ),
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
The versions of the dependencies required for unit testing were not specified in `setup.py`, causing the CI pipeline to fail as newer versions, not compatible with Python 3.6, become available.